### PR TITLE
Update README links

### DIFF
--- a/README
+++ b/README
@@ -6,8 +6,8 @@ This project is maintained at https://code.google.com/p/googlecrisismap/.
 
 To deploy your own running copy of the app, see:
 
-    https://code.google.com/p/googlecrisismap/wiki/Deploying
+    https://github.com/google/googlecrisismap/wiki/Deploying
 
 To get started developing the code, see:
 
-    https://code.google.com/p/googlecrisismap/wiki/GettingStarted
+    https://github.com/google/googlecrisismap/wiki/Getting-Started


### PR DESCRIPTION
The links just go back to the GitHub repo. It looks like there is a general URL redirect that doesn't link directly to the right pages. 

The suggested edits fixes the urls. 